### PR TITLE
Reduce spacing and consolidate language card

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -44,7 +44,7 @@ header p {
 main {
     padding: 2em;
     display: grid;
-    gap: 1.5em;
+    gap: 1em;
 }
 
 
@@ -104,7 +104,7 @@ html {
 }
 
 .card {
-    margin-bottom: 1.5em;
+    margin-bottom: 1em;
     background-color: #ffffff;
     border-radius: 20px;
     padding: 2em;
@@ -115,7 +115,7 @@ h2 {
     font-family: 'Playfair Display', serif;
     color: #ffffff;
     font-size: 2em;
-    margin-top: 2.5em;
-    margin-bottom: 0.8em;
+    margin-top: 1.5em;
+    margin-bottom: 0.4em;
     text-align: center;
 }

--- a/index.html
+++ b/index.html
@@ -67,13 +67,9 @@
 
         <h2 id="idiomas">Idiomas</h2>
         <section class="card">
-            <strong>Español:</strong> Nativo
-        </section>
-        <section class="card">
-            <strong>Inglés:</strong> C1 (CAE)
-        </section>
-        <section class="card">
-            <strong>Francés:</strong> B1
+            <p><strong>Español:</strong> Nativo</p>
+            <p><strong>Inglés:</strong> C1 (CAE)</p>
+            <p><strong>Francés:</strong> B1</p>
         </section>
     </main>
     <footer>


### PR DESCRIPTION
## Summary
- shrink space around cards and titles
- show all languages in one card

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d484d8f148324b1704f19f446be63